### PR TITLE
chore: set app and server ports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -37,7 +37,7 @@ app.post('/api/contact', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 6001;
 app.listen(PORT, () => {
   console.log(`Email server listening on port ${PORT}`);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 6000,
+    proxy: {
+      '/api': 'http://localhost:6001',
+    },
+  },
+  preview: {
+    port: 6000,
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- run Vite dev and preview servers on port 6000
- proxy API requests to backend running on port 6001
- set Express server default port to 6001

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c694c4fb1c832397e92d72e6851c66