### PR TITLE
Use dotenv to configure email server for contact form submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-router-dom": "^7.8.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "nodemailer": "^6.9.12"
+    "nodemailer": "^6.9.12",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,9 @@
+import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import nodemailer from 'nodemailer';
+
+dotenv.config();
 
 const app = express();
 app.use(cors());


### PR DESCRIPTION
## Summary
- load environment variables at server startup so contact emails can be sent via nodemailer
- add dotenv dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e08c4438832387fc872e7f3a96d0