### PR TITLE
fix: correct break tags in Contact page

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -91,8 +91,8 @@ const Contact = () => {
                   </div>
                   <div>
                     <h3 className="text-white font-semibold">Location</h3>
-                    <p className="text-slate-300">7 Perlman Dr<br>
-                      unit 218 <br>Spring Valley, NY 10977</p>
+                    <p className="text-slate-300">7 Perlman Dr<br />
+                      unit 218 <br />Spring Valley, NY 10977</p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- fix unclosed `<br>` tags in Contact page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70e7199808323998a691741fe700e