### PR TITLE
Add logging for contact form submission

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,8 +10,10 @@ app.use(cors());
 app.use(express.json());
 
 app.post('/api/contact', async (req, res) => {
+  console.log('Received contact form submission', req.body);
   const { name, email, subject, message } = req.body;
   if (!name || !email || !subject || !message) {
+    console.warn('Contact form missing fields', req.body);
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
@@ -33,9 +35,10 @@ app.post('/api/contact', async (req, res) => {
       subject: subject || `New message from ${name}`,
       text: `Name: ${name}\nEmail: ${email}\n\n${message}`
     });
+    console.log('Email sent successfully');
     res.status(200).json({ ok: true });
   } catch (err) {
-    console.error(err);
+    console.error('Error sending email', err);
     res.status(500).json({ error: 'Failed to send email' });
   }
 });

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -18,20 +18,25 @@ const Contact = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    console.log('Submitting contact form', formData);
     try {
       const response = await fetch('/api/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)
       });
+      console.log('Received response from server', response.status);
 
       if (!response.ok) {
+        console.error('Form submission failed', response.status);
         throw new Error('Network response was not ok');
       }
 
+      console.log('Form submission succeeded');
       alert('התודה! ההודעה נשלחה בהצלחה');
       setFormData({ name: '', email: '', subject: '', message: '' });
-    } catch {
+    } catch (error) {
+      console.error('Error submitting contact form', error);
       alert('שליחת ההודעה נכשלה, נסה שוב מאוחר יותר');
     }
   };


### PR DESCRIPTION
## Summary
- add client-side console logs around contact form submission
- log contact form requests and email sending on the server

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c70f4fb45c8323b88d8381f583a884