### PR TITLE
feat: configure api base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+VITE_API_BASE_URL=http://api.govividmedia.70-60.com
 SMTP_HOST=smtp.hostinger.com
 SMTP_PORT=465
 SMTP_USER=govividmedia@70-60.com

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ app.use(cors());
 app.use(express.json());
 
 app.post('/api/contact', async (req, res) => {
+  console.log('Request reached server at', req.headers.host);
   console.log('Received contact form submission', req.body);
   const { name, email, subject, message } = req.body;
   if (!name || !email || !subject || !message) {

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -8,6 +8,8 @@ interface ContactFormData {
   message: string;
 }
 
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://api.govividmedia.70-60.com').replace(/\/$/, '');
+
 const Contact = () => {
   const [formData, setFormData] = useState<ContactFormData>({
     name: '',
@@ -18,14 +20,15 @@ const Contact = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('Submitting contact form', formData);
+    const endpoint = `${API_BASE_URL}/api/contact`;
+    console.log('Submitting contact form', formData, 'to', endpoint);
     try {
-      const response = await fetch('/api/contact', {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)
       });
-      console.log('Received response from server', response.status);
+      console.log('Received response from', response.url, 'status', response.status);
 
       if (!response.ok) {
         console.error('Form submission failed', response.status);


### PR DESCRIPTION
## Summary
- default API URL set to `http://api.govividmedia.70-60.com`
- log full contact endpoint on submit to verify requests hit the expected server
- log incoming request host on backend for debugging

## Testing
- `npm ci --ignore-scripts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c712396f0c832386ad2ccf693f572c