### PR TITLE
fix: use https for contact API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=http://api.govividmedia.70-60.com
+VITE_API_BASE_URL=https://api.govividmedia.70-60.com
 SMTP_HOST=smtp.hostinger.com
 SMTP_PORT=465
 SMTP_USER=govividmedia@70-60.com

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -8,7 +8,7 @@ interface ContactFormData {
   message: string;
 }
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://api.govividmedia.70-60.com').replace(/\/$/, '');
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'https://api.govividmedia.70-60.com').replace(/\/$/, '');
 
 const Contact = () => {
   const [formData, setFormData] = useState<ContactFormData>({


### PR DESCRIPTION
## Summary
- default contact API base URL to HTTPS to avoid mixed content
- update example environment file to use the secure API endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7269b5ae8832381d3c872472b2911