### PR TITLE
feat: add admin portfolio editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ SMTP_USER=govividmedia@70-60.com
 SMTP_PASS="goVividmedia1@"
 SMTP_FROM=govividmedia@70-60.com
 CONTACT_RECIPIENT=govividmedia@70-60.com
+ADMIN_PASSWORD=changeme
+VITE_ADMIN_PASSWORD=changeme

--- a/server/portfolio.json
+++ b/server/portfolio.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": 1,
+    "title": "Global Brand Campaign",
+    "category": "branding",
+    "description": "Complete brand identity and multi-channel campaign for international tech startup",
+    "image": "https://images.pexels.com/photos/196644/pexels-photo-196644.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Brand Strategy", "Visual Identity", "Campaign Management"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 2,
+    "title": "Social Media Strategy",
+    "category": "social",
+    "description": "Comprehensive social media campaign that increased engagement by 300%",
+    "image": "https://images.pexels.com/photos/607812/pexels-photo-607812.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Social Media", "Content Creation", "Analytics"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 3,
+    "title": "Product Launch Campaign",
+    "category": "campaigns",
+    "description": "Integrated marketing campaign for major product launch with 500% ROI",
+    "image": "https://images.pexels.com/photos/196644/pexels-photo-196644.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Product Launch", "PR", "Digital Advertising"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 4,
+    "title": "Google Ads Optimization",
+    "category": "digital",
+    "description": "PPC campaign optimization that reduced cost-per-click by 40% while doubling conversions",
+    "image": "https://images.pexels.com/photos/230544/pexels-photo-230544.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Google Ads", "PPC", "Conversion Optimization"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 5,
+    "title": "Influencer Marketing",
+    "category": "social",
+    "description": "Strategic influencer partnerships that generated 2M+ impressions and 15% sales increase",
+    "image": "https://images.pexels.com/photos/265087/pexels-photo-265087.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Influencer Marketing", "Partnership Management", "ROI Tracking"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 6,
+    "title": "Email Marketing Automation",
+    "category": "digital",
+    "description": "Automated email sequences that increased customer retention by 45%",
+    "image": "https://images.pexels.com/photos/270408/pexels-photo-270408.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Email Marketing", "Automation", "Customer Retention"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 7,
+    "title": "Video Marketing Campaign",
+    "category": "content",
+    "description": "Viral video series that reached 5M+ views and increased brand awareness by 200%",
+    "image": "https://images.pexels.com/photos/3153198/pexels-photo-3153198.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Video Production", "Viral Marketing", "Brand Awareness"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 8,
+    "title": "SEO & Content Strategy",
+    "category": "digital",
+    "description": "Comprehensive SEO strategy that improved organic traffic by 250% in 6 months",
+    "image": "https://images.pexels.com/photos/270637/pexels-photo-270637.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["SEO", "Content Strategy", "Organic Growth"],
+    "link": "#",
+    "github": "#"
+  },
+  {
+    "id": 9,
+    "title": "Event Marketing",
+    "category": "campaigns",
+    "description": "Large-scale event promotion that sold out 5,000 tickets in 48 hours",
+    "image": "https://images.pexels.com/photos/1190298/pexels-photo-1190298.jpeg?auto=compress&cs=tinysrgb&w=600",
+    "tags": ["Event Marketing", "Ticket Sales", "Promotion Strategy"],
+    "link": "#",
+    "github": "#"
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Navigation from './components/Navigation';
 import Home from './pages/Home';
 import Contact from './pages/Contact';
 import Portfolio from './pages/Portfolio';
+import Admin from './pages/Admin';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/portfolio" element={<Portfolio />} />
+          <Route path="/admin" element={<Admin />} />
         </Routes>
       </div>
     </Router>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,152 @@
+import React, { useState, useEffect } from 'react';
+
+interface Project {
+  id: number;
+  title: string;
+  category: string;
+  description: string;
+  image: string;
+  tags: string[];
+  link: string;
+  github: string;
+}
+
+const Admin = () => {
+  const [password, setPassword] = useState('');
+  const [authed, setAuthed] = useState(false);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [form, setForm] = useState({
+    title: '',
+    category: '',
+    description: '',
+    image: '',
+    tags: '',
+    link: '',
+    github: ''
+  });
+
+  const loadProjects = async () => {
+    const res = await fetch('/api/projects');
+    const data = await res.json();
+    setProjects(data);
+  };
+
+  useEffect(() => {
+    if (authed) {
+      loadProjects();
+    }
+  }, [authed]);
+
+  const login = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password === import.meta.env.VITE_ADMIN_PASSWORD) {
+      setAuthed(true);
+    }
+  };
+
+  const addProject = async () => {
+    const body = {
+      ...form,
+      tags: form.tags.split(',').map(t => t.trim()).filter(Boolean)
+    };
+    await fetch('/api/projects', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-admin-secret': password
+      },
+      body: JSON.stringify(body)
+    });
+    setForm({ title: '', category: '', description: '', image: '', tags: '', link: '', github: '' });
+    loadProjects();
+  };
+
+  const deleteProject = async (id: number) => {
+    await fetch(`/api/projects/${id}`, {
+      method: 'DELETE',
+      headers: { 'x-admin-secret': password }
+    });
+    loadProjects();
+  };
+
+  if (!authed) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-900">
+        <form onSubmit={login} className="bg-slate-800 p-8 rounded-lg shadow-lg space-y-4">
+          <h2 className="text-white text-xl">Admin Login</h2>
+          <input
+            type="password"
+            className="w-full p-2 rounded"
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <button type="submit" className="w-full bg-white text-slate-900 p-2 rounded">Login</button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-900 p-8 text-white">
+      <h1 className="text-2xl mb-4">Portfolio Admin</h1>
+
+      <div className="mb-8 space-y-2">
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Title"
+          value={form.title}
+          onChange={e => setForm({ ...form, title: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Category"
+          value={form.category}
+          onChange={e => setForm({ ...form, category: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Description"
+          value={form.description}
+          onChange={e => setForm({ ...form, description: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Image URL"
+          value={form.image}
+          onChange={e => setForm({ ...form, image: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Tags (comma separated)"
+          value={form.tags}
+          onChange={e => setForm({ ...form, tags: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Link"
+          value={form.link}
+          onChange={e => setForm({ ...form, link: e.target.value })}
+        />
+        <input
+          className="w-full p-2 rounded text-slate-900"
+          placeholder="Github"
+          value={form.github}
+          onChange={e => setForm({ ...form, github: e.target.value })}
+        />
+        <button onClick={addProject} className="bg-white text-slate-900 px-4 py-2 rounded">Add Project</button>
+      </div>
+
+      <ul className="space-y-2">
+        {projects.map(p => (
+          <li key={p.id} className="flex justify-between items-center bg-slate-800 p-2 rounded">
+            <span>{p.title}</span>
+            <button onClick={() => deleteProject(p.id)} className="text-red-400">Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Admin;

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,101 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ExternalLink, Github, ArrowRight, Filter } from 'lucide-react';
+
+type Project = {
+  id: number;
+  title: string;
+  category: string;
+  description: string;
+  image: string;
+  tags: string[];
+  link: string;
+  github: string;
+};
 
 const Portfolio = () => {
   const [selectedCategory, setSelectedCategory] = useState('all');
+  const [projects, setProjects] = useState<Project[]>([]);
 
-  const projects = [
-    {
-      id: 1,
-      title: 'Global Brand Campaign',
-      category: 'branding',
-      description: 'Complete brand identity and multi-channel campaign for international tech startup',
-      image: 'https://images.pexels.com/photos/196644/pexels-photo-196644.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Brand Strategy', 'Visual Identity', 'Campaign Management'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 2,
-      title: 'Social Media Strategy',
-      category: 'social',
-      description: 'Comprehensive social media campaign that increased engagement by 300%',
-      image: 'https://images.pexels.com/photos/607812/pexels-photo-607812.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Social Media', 'Content Creation', 'Analytics'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 3,
-      title: 'Product Launch Campaign',
-      category: 'campaigns',
-      description: 'Integrated marketing campaign for major product launch with 500% ROI',
-      image: 'https://images.pexels.com/photos/196644/pexels-photo-196644.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Product Launch', 'PR', 'Digital Advertising'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 4,
-      title: 'Google Ads Optimization',
-      category: 'digital',
-      description: 'PPC campaign optimization that reduced cost-per-click by 40% while doubling conversions',
-      image: 'https://images.pexels.com/photos/230544/pexels-photo-230544.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Google Ads', 'PPC', 'Conversion Optimization'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 5,
-      title: 'Influencer Marketing',
-      category: 'social',
-      description: 'Strategic influencer partnerships that generated 2M+ impressions and 15% sales increase',
-      image: 'https://images.pexels.com/photos/265087/pexels-photo-265087.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Influencer Marketing', 'Partnership Management', 'ROI Tracking'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 6,
-      title: 'Email Marketing Automation',
-      category: 'digital',
-      description: 'Automated email sequences that increased customer retention by 45%',
-      image: 'https://images.pexels.com/photos/270408/pexels-photo-270408.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Email Marketing', 'Automation', 'Customer Retention'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 7,
-      title: 'Video Marketing Campaign',
-      category: 'content',
-      description: 'Viral video series that reached 5M+ views and increased brand awareness by 200%',
-      image: 'https://images.pexels.com/photos/3153198/pexels-photo-3153198.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Video Production', 'Viral Marketing', 'Brand Awareness'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 8,
-      title: 'SEO & Content Strategy',
-      category: 'digital',
-      description: 'Comprehensive SEO strategy that improved organic traffic by 250% in 6 months',
-      image: 'https://images.pexels.com/photos/270637/pexels-photo-270637.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['SEO', 'Content Strategy', 'Organic Growth'],
-      link: '#',
-      github: '#'
-    },
-    {
-      id: 9,
-      title: 'Event Marketing',
-      category: 'campaigns',
-      description: 'Large-scale event promotion that sold out 5,000 tickets in 48 hours',
-      image: 'https://images.pexels.com/photos/1190298/pexels-photo-1190298.jpeg?auto=compress&cs=tinysrgb&w=600',
-      tags: ['Event Marketing', 'Ticket Sales', 'Promotion Strategy'],
-      link: '#',
-      github: '#'
-    }
-  ];
+  useEffect(() => {
+    fetch('/api/projects')
+      .then(res => res.json())
+      .then(data => setProjects(data))
+      .catch(() => setProjects([]));
+  }, []);
 
   const categories = [
     { id: 'all', label: 'All' },


### PR DESCRIPTION
## Summary
- add server-side storage and API for portfolio projects
- create password-protected admin page to manage projects
- load portfolio data from server instead of hardcoding

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68c7dfae31e48323b6e7e0930acc9e94