### PR TITLE
feat: refresh home hero and add mobile video

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,17 +6,29 @@ const Home = () => {
   return (
     <div className="relative min-h-screen overflow-hidden">
       {/* Video Background */}
-      <div className="absolute inset-0 z-0">
+      <div className="absolute inset-0 z-0 overflow-hidden">
         <video
           autoPlay
           muted
           loop
           playsInline
-          className="w-full h-full object-cover"
+          className="hidden h-full w-full object-cover sm:block"
         >
-          <source src="/export 1.mp4" type="video/mp4" />
-          {/* Fallback gradient if video doesn't load */}
+          <source src="/export%201.mp4" type="video/mp4" />
         </video>
+
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          className="h-full w-full object-cover sm:hidden"
+        >
+          <source src="/phone%20size.mp4" type="video/mp4" />
+        </video>
+
+        <div className="pointer-events-none absolute inset-0 bg-slate-900/30 mix-blend-multiply" />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-slate-900/40 via-slate-900/20 to-slate-950/70" />
       </div>
 
       {/* Content */}
@@ -24,30 +36,41 @@ const Home = () => {
         <div className="max-w-7xl mx-auto w-full">
           <div className="flex justify-center lg:justify-end">
             <div className="max-w-2xl text-center lg:mr-16">
-          <h1 className="text-5xl md:text-7xl lg:text-8xl font-chewy text-white mb-16 leading-tight">
-            <span className="block text-white mb-2">Brainstorming</span>
-            <span className="block text-white text-5xl md:text-7xl lg:text-8xl">in progress</span>
-          </h1>
-          
-              <p className="text-xl md:text-2xl text-slate-300 mb-12 leading-relaxed font-knewave mt-32">
-            Where we brainstorm, to put you in the spotlight
-          </p>
+              <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/50 px-6 py-10 shadow-[0_30px_60px_rgba(15,23,42,0.55)] backdrop-blur-md sm:px-12">
+                <div className="pointer-events-none absolute -top-24 -right-16 h-56 w-56 rounded-full bg-cyan-400/30 blur-3xl" />
+                <div className="pointer-events-none absolute -bottom-28 -left-20 h-64 w-64 rounded-full bg-fuchsia-500/20 blur-3xl" />
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <Link 
-                  to="/contact"
-                  className="group bg-white hover:bg-gray-100 text-slate-900 font-semibold py-4 px-8 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl inline-flex items-center"
-                >
-                  Get in Touch
-              <span className="inline-block transition-transform group-hover:translate-x-1 ml-2">→</span>
-                </Link>
-            
-                <Link 
-                  to="/portfolio"
-                  className="group border-2 border-white/20 hover:border-white/40 text-white font-semibold py-4 px-8 rounded-full transition-all duration-300 backdrop-blur-sm hover:backdrop-blur-md"
-                >
-                  Get a Glimpse
-                </Link>
+                <div className="relative">
+                  <span className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-white/80">
+                    Creative Minds at Work
+                  </span>
+
+                  <h1 className="text-4xl font-chewy leading-tight text-white sm:text-5xl md:text-7xl lg:text-8xl">
+                    <span className="block text-white">Brainstorming</span>
+                    <span className="mt-2 block text-white">in progress</span>
+                  </h1>
+
+                  <p className="mt-8 text-lg font-knewave leading-relaxed text-slate-200 sm:text-xl md:text-2xl">
+                    Where we brainstorm, to put you in the spotlight
+                  </p>
+
+                  <div className="mt-12 flex flex-col items-center justify-center gap-4 sm:flex-row">
+                    <Link
+                      to="/contact"
+                      className="group inline-flex items-center rounded-full bg-white px-8 py-4 font-semibold text-slate-900 shadow-lg transition-all duration-300 hover:scale-105 hover:bg-gray-100 hover:shadow-xl"
+                    >
+                      Get in Touch
+                      <span className="ml-2 inline-block transition-transform group-hover:translate-x-1">→</span>
+                    </Link>
+
+                    <Link
+                      to="/portfolio"
+                      className="group inline-flex items-center rounded-full border-2 border-white/30 px-8 py-4 font-semibold text-white transition-all duration-300 backdrop-blur-sm hover:border-white/60 hover:backdrop-blur-md"
+                    >
+                      Get a Glimpse
+                    </Link>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- refresh the home hero container with a glassmorphism card and accent highlights for a richer look
- add a dedicated mobile background video that swaps in on small screens
- layer gradient overlays to improve text legibility on top of either background clip

## Testing
- npm run lint *(fails: registry returned 403 for @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68c9527ba37c8323855709485f914c36