### PR TITLE
Use default font for home page tagline

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -29,7 +29,7 @@ const Home = () => {
             <span className="block text-white text-5xl md:text-7xl lg:text-8xl">in progress</span>
           </h1>
           
-              <p className="text-xl md:text-2xl text-slate-300 mb-12 leading-relaxed font-knewave mt-32">
+              <p className="text-xl md:text-2xl text-slate-300 mb-12 leading-relaxed mt-32">
             Where we brainstorm, to put you in the spotlight
           </p>
 


### PR DESCRIPTION
## Summary
- remove the decorative font class from the home page tagline so it renders with the default typeface

## Testing
- npm run build *(fails: vite not found because dependencies are unavailable in the execution environment)*
- npm install *(fails: registry responded 403 to cors package request in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97220ad70832396fa997694da24f8