### PR TITLE
Add logging for portfolio API fetch

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -17,10 +17,49 @@ const Portfolio = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
   useEffect(() => {
-    fetch('/api/projects')
-      .then(res => res.json())
-      .then(data => setProjects(data))
-      .catch(() => setProjects([]));
+    const endpoint = '/api/projects';
+    const resolvedUrl = (() => {
+      try {
+        return new URL(endpoint, window.location.origin).toString();
+      } catch (error) {
+        console.error('[Portfolio] Failed to resolve API URL', { endpoint, error });
+        return endpoint;
+      }
+    })();
+
+    console.log('[Portfolio] Attempting to fetch projects from server', {
+      endpoint,
+      resolvedUrl,
+    });
+
+    fetch(endpoint)
+      .then((res) => {
+        console.log('[Portfolio] Received response from server', {
+          endpoint: resolvedUrl,
+          status: res.status,
+          ok: res.ok,
+        });
+
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+
+        return res.json();
+      })
+      .then((data: Project[]) => {
+        console.log('[Portfolio] Successfully loaded projects', {
+          endpoint: resolvedUrl,
+          count: data.length,
+        });
+        setProjects(data);
+      })
+      .catch((error) => {
+        console.error('[Portfolio] Failed to fetch projects from server', {
+          endpoint: resolvedUrl,
+          error,
+        });
+        setProjects([]);
+      });
   }, []);
 
   const categories = [


### PR DESCRIPTION
## Summary
- add detailed client-side logging for the portfolio page to trace API requests and resolved server URLs
- log success, failure, and project counts to help debug connectivity issues

## Testing
- npm run build *(fails: local vite binary unavailable because registry access to download dependencies is forbidden in this environment)*
- npm run lint *(fails: missing @eslint/js dependency for the same registry access restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68c9728ca7288323a8f9012a6911280c