### PR TITLE
Use mobile-specific background video on home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,9 +12,19 @@ const Home = () => {
           muted
           loop
           playsInline
-          className="w-full h-full object-cover"
+          className="hidden w-full h-full object-cover md:block"
         >
           <source src="/export 1.mp4" type="video/mp4" />
+          {/* Fallback gradient if video doesn't load */}
+        </video>
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          className="w-full h-full object-cover md:hidden"
+        >
+          <source src="/phone size.mp4" type="video/mp4" />
           {/* Fallback gradient if video doesn't load */}
         </video>
       </div>


### PR DESCRIPTION
## Summary
- show the existing desktop video only on medium+ screens and introduce a mobile-friendly background video for smaller viewports

## Testing
- Unable to run tests (npm install failed with 403 Forbidden from npm registry)


------
https://chatgpt.com/codex/tasks/task_e_68c973c22a188323984a01fdc29833b5