### PR TITLE
Split portfolio hero subtitle into two lines

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -45,7 +45,8 @@ const Portfolio = () => {
             <span className="text-white">Our</span> Success Stories
           </h1>
           <p className="text-xl text-slate-300 max-w-2xl mx-auto">
-            Explore our award-winning campaigns and marketing strategies that drive real results
+            <span className="block">Explore our award-winning campaigns and marketing strategies</span>
+            <span className="block">that drive real results</span>
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- wrap the portfolio hero subtitle in block spans so the copy always renders on two lines

## Testing
- npm run lint *(fails: missing @eslint/js dependency because the npm registry is inaccessible from this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9725a68d483239e39d49cb75e16ca