### PR TITLE
Use configured API host for portfolio and admin

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { buildApiUrl } from '../utils/api';
 
 interface Project {
   id: number;
@@ -26,7 +27,8 @@ const Admin = () => {
   });
 
   const loadProjects = async () => {
-    const res = await fetch('/api/projects');
+    const endpoint = buildApiUrl('/api/projects');
+    const res = await fetch(endpoint);
     const data = await res.json();
     setProjects(data);
   };
@@ -49,7 +51,7 @@ const Admin = () => {
       ...form,
       tags: form.tags.split(',').map(t => t.trim()).filter(Boolean)
     };
-    await fetch('/api/projects', {
+    await fetch(buildApiUrl('/api/projects'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -62,7 +64,7 @@ const Admin = () => {
   };
 
   const deleteProject = async (id: number) => {
-    await fetch(`/api/projects/${id}`, {
+    await fetch(buildApiUrl(`/api/projects/${id}`), {
       method: 'DELETE',
       headers: { 'x-admin-secret': password }
     });

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Mail, Phone, MapPin, Send, MessageCircle } from 'lucide-react';
+import { buildApiUrl } from '../utils/api';
 
 interface ContactFormData {
   name: string;
@@ -7,8 +8,6 @@ interface ContactFormData {
   subject: string;
   message: string;
 }
-
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'https://api.govividmedia.70-60.com').replace(/\/$/, '');
 
 const Contact = () => {
   const [formData, setFormData] = useState<ContactFormData>({
@@ -20,7 +19,7 @@ const Contact = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const endpoint = `${API_BASE_URL}/api/contact`;
+    const endpoint = buildApiUrl('/api/contact');
     console.log('Submitting contact form', formData, 'to', endpoint);
     try {
       const response = await fetch(endpoint, {

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ExternalLink, Github, ArrowRight, Filter } from 'lucide-react';
+import { buildApiUrl } from '../utils/api';
 
 type Project = {
   id: number;
@@ -17,25 +18,16 @@ const Portfolio = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
   useEffect(() => {
-    const endpoint = '/api/projects';
-    const resolvedUrl = (() => {
-      try {
-        return new URL(endpoint, window.location.origin).toString();
-      } catch (error) {
-        console.error('[Portfolio] Failed to resolve API URL', { endpoint, error });
-        return endpoint;
-      }
-    })();
+    const endpoint = buildApiUrl('/api/projects');
 
     console.log('[Portfolio] Attempting to fetch projects from server', {
       endpoint,
-      resolvedUrl,
     });
 
     fetch(endpoint)
       .then((res) => {
         console.log('[Portfolio] Received response from server', {
-          endpoint: resolvedUrl,
+          endpoint,
           status: res.status,
           ok: res.ok,
         });
@@ -48,14 +40,14 @@ const Portfolio = () => {
       })
       .then((data: Project[]) => {
         console.log('[Portfolio] Successfully loaded projects', {
-          endpoint: resolvedUrl,
+          endpoint,
           count: data.length,
         });
         setProjects(data);
       })
       .catch((error) => {
         console.error('[Portfolio] Failed to fetch projects from server', {
-          endpoint: resolvedUrl,
+          endpoint,
           error,
         });
         setProjects([]);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,20 @@
+const DEFAULT_API_BASE_URL = 'https://api.govividmedia.70-60.com';
+
+const sanitizeBaseUrl = (url: string) => url.replace(/\/$/, '');
+
+const resolveBaseUrl = () => {
+  const envValue = import.meta.env.VITE_API_BASE_URL;
+  if (envValue && envValue.trim().length > 0) {
+    return sanitizeBaseUrl(envValue);
+  }
+  return sanitizeBaseUrl(DEFAULT_API_BASE_URL);
+};
+
+export const API_BASE_URL = resolveBaseUrl();
+
+export const buildApiUrl = (path: string) => {
+  if (!path || path === '/') {
+    return API_BASE_URL;
+  }
+  return `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+};


### PR DESCRIPTION
## Summary
- centralize the API base URL with a shared utility that defaults to https://api.govividmedia.70-60.com
- update the portfolio page to fetch projects from the configured server URL
- update the admin dashboard API calls to use the configured server URL

## Testing
- npm run build *(fails: vite missing because npm install is blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c97704068c832394c8c4426a4e3906