### PR TITLE
Fix portfolio data file path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,11 +4,13 @@ import cors from 'cors';
 import nodemailer from 'nodemailer';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 const app = express();
 
 // ===== Simple file storage for portfolio projects =====
-const dataFile = path.join(process.cwd(), 'server', 'portfolio.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataFile = path.join(__dirname, 'portfolio.json');
 
 function readProjects() {
   try {


### PR DESCRIPTION
## Summary
- ensure the API server resolves the portfolio data file relative to the server directory so deployments can load the JSON data

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7e1664c8323a194fbffe59b4774